### PR TITLE
Update doc and examples of ALERT RDY conversion-ready mode register config

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,10 @@ even if actual value has been 'restored to normal' value.
 Set the number of conversions before trigger activates.
 The **void setComparatorQueConvert(uint8_t mode)** is used to set the number of
 conversions that exceed the threshold before the **ALERT/RDY** pin is set **HIGH**.
-A value of 3 (or above) effectively disables the comparator. See table below.
+A value of 3 (or above) effectively disables the comparator. See table below. 
+To enable the conversion-ready function of the ALERT/RDY pin, it is necessary to set the MSB of the Hi_thresh register to 1 and the MSB of the Lo_thresh register to 0.
+
+See [examples](https://github.com/RobTillaart/ADS1X15/blob/master/examples/ADS_continuous_differential/ADS_continuous_differential.ino).
 
 - **void setComparatorQueConvert(uint8_t mode)** See table below.
 - **uint8_t getComparatorQueConvert()**  returns value set.

--- a/examples/ADS_continuous_differential/ADS_continuous_differential.ino
+++ b/examples/ADS_continuous_differential/ADS_continuous_differential.ino
@@ -55,8 +55,10 @@ void setup()
   ADS.setDataRate(0);    // 0 = slow   4 = medium   7 = fast  (7 = fails )
   // every step is about a factor 2 slower.
 
-  // SET ALERT RDY PIN
+  // SET ALERT RDY PIN (QueConvert mode)
+  // set the MSB of the Hi_thresh register to 1
   ADS.setComparatorThresholdHigh(0x8000);
+  // set the MSB of the Lo_thresh register to 0
   ADS.setComparatorThresholdLow(0x0000);
   ADS.setComparatorQueConvert(0);
 

--- a/examples/ADS_high_speed_differential/ADS_high_speed_differential.ino
+++ b/examples/ADS_high_speed_differential/ADS_high_speed_differential.ino
@@ -39,8 +39,10 @@ void setup()
   ADS_1.setGain(0);        // 6.144 volt
   ADS_1.setDataRate(7);    // 0 = slow   4 = medium   7 = fast
 
-  // SET ALERT RDY PIN
+  // SET ALERT RDY PIN (QueConvert mode)
+  // set the MSB of the Hi_thresh register to 1
   ADS_1.setComparatorThresholdHigh(0x8000);
+  // set the MSB of the Lo_thresh register to 0
   ADS_1.setComparatorThresholdLow(0x0000);
   ADS_1.setComparatorQueConvert(0);
 
@@ -58,7 +60,9 @@ void setup()
   ADS_2.setDataRate(7);
 
   // SET ALERT RDY PIN
+  // set the MSB of the Hi_thresh register to 1
   ADS_2.setComparatorThresholdHigh(0x8000);
+  // set the MSB of the Lo_thresh register to 0
   ADS_2.setComparatorThresholdLow(0x0000);
   ADS_2.setComparatorQueConvert(0);
 


### PR DESCRIPTION
About this PR
- Add the note about using register config in conversion-ready mode
- Add comments for the setComparatorThreshold calls in the examples.

Signed-off-by chip@snakeoildev.com

